### PR TITLE
Throttles each syncable attribute of avatars separately

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>A-Frame multi-user Croquet component</title>
   <script src="https://unpkg.com/@croquet/croquet"></script>
-  <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+  <script src="https://aframe.io/releases/1.4.1/aframe.min.js"></script>
   <script src="./lib/aframe-croquet-component.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/dougreeder/aframe-extras@052a1f4617f606e951650810cff116e404b886e5/dist/aframe-extras.controls.js"></script>
 </head>


### PR DESCRIPTION
* Using separate throttled functions ensures that if the position and rotation of the avatar are changing, one won't prevent the other from updating, and is more efficient that polling.
* Using _throttleLeadingAndTrailing_ ensures that infrequent updates are synced as soon as possible, and the last update of a burst gets synced.
* tweaks logging levels, so console isn't spammed when debug logging is turned off in the browser console