### PR TITLE
Fixes bug where ANode is not visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aframe-croquet-component",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aframe-croquet-component",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "budo": "^11.8.4"

--- a/public/lib/aframe-croquet-component.js
+++ b/public/lib/aframe-croquet-component.js
@@ -707,7 +707,7 @@ AFRAME.registerComponent('multiuser', {
             // Not a component. Normal set attribute.
             if (!COMPONENTS[componentName]) {
                 if (attrName === 'mixin') { this.mixinUpdate(arg1); }
-                ANode.prototype.setAttribute.call(this, attrName, arg1);
+                AFRAME.ANode.prototype.setAttribute.call(this, attrName, arg1);
                 return;
             }
 
@@ -765,7 +765,7 @@ AFRAME.registerComponent('multiuser', {
             // Not a component. Normal set attribute.
             if (!COMPONENTS[componentName]) {
                 if (attrName === 'mixin') { this.mixinUpdate(arg1); }
-                ANode.prototype.setAttribute.call(this, attrName, arg1);
+                AFRAME.ANode.prototype.setAttribute.call(this, attrName, arg1);
                 return;
             }
 


### PR DESCRIPTION
There are configurations where ANode is not visible as a global, but it's always available on AFRAME.